### PR TITLE
Fix reference in `DTUSputtering.add_libraries`

### DIFF
--- a/src/nomad_dtu_nanolab_plugin/schema_packages/sample.py
+++ b/src/nomad_dtu_nanolab_plugin/schema_packages/sample.py
@@ -373,7 +373,7 @@ class UniqueXrdPeaksReference(EntityReference):
     )
 
 
-class ProcessParameterOverview(Schema):
+class ProcessParameterOverview(ArchiveSection):
     m_def = Section(
         categories=[DTUNanolabCategory],
         label='Process Parameter Overview',
@@ -432,8 +432,8 @@ class DTUCombinatorialLibrary(CombinatorialLibrary, ThinFilmStack, Schema):
         label='Combinatorial Library',
     )
 
-    process_parameter_overview = Quantity(
-        type=ProcessParameterOverview,
+    process_parameter_overview = SubSection(
+        section_def=ProcessParameterOverview,
         description='An overview of the process parameters used to create the library.',
     )
 

--- a/src/nomad_dtu_nanolab_plugin/schema_packages/sputtering.py
+++ b/src/nomad_dtu_nanolab_plugin/schema_packages/sputtering.py
@@ -2678,7 +2678,7 @@ class DTUSputtering(SputterDeposition, PlotSection, Schema):
                 substrate_mounting.substrate.m_proxy_resolve()
             library = DTUCombinatorialLibrary()
             library.substrate = SubstrateReference(
-                reference=substrate_mounting.substrate
+                reference=substrate_mounting.substrate.m_proxy_value
             )
             sample_id = str(idx)
             if substrate_mounting.name is not None:


### PR DESCRIPTION
When creating an entry for `library: DTUCombinatorialLibrary` based on the substrates from `DTUSputtering` class, we want to copy the reference path (m_proxy_value) of the referenced substrate in `DTUSputtering.substrates[i]` to the newly created library. But currently, the saved reference in `library` entry has the value `/data` rather than something of the form `../uploads/<upload-id>/archive/<entry-id>#/data`; hence, the reference of the substrate in `library` entry is not available.

Probable cause:
We have been assigning the resolved substrate section to `library.substrate.reference`. The `m_to_dict` (which we use in `create_archive`) loses the upload context for this section after resolution and generates a value of `/data`.

Fix:
The resolved section itself has an attribute `m_proxy_value`, which contains the complete reference with the upload context. This should be assigned to `library.substrate.reference` instead.

Additionally:
`m_to_dict` also converts the section `library.process_parameter_overview: ProcessParameterOverview` to the value `/`. This is because `library.process_parameter_overview` is defined to be a quantity in the schema, whereas we are assigning it a section. Fixing this by defining `library.process_parameter_overview` as a `SubSection`.