### PR TITLE
211 enhancing dtucombinatoriallibrary class

### DIFF
--- a/src/nomad_dtu_nanolab_plugin/schema_packages/sample.py
+++ b/src/nomad_dtu_nanolab_plugin/schema_packages/sample.py
@@ -48,9 +48,9 @@ if TYPE_CHECKING:
     from nomad_dtu_nanolab_plugin.schema_packages.sputtering import DTUSputtering
 
 # Constants
-MAX_SPACE_GROUP_NUMBER = 231  # 1-230 space groups, so range goes to 231
+MAX_SPACE_GROUP_NUMBER = 230  # 1-230 space groups, so range goes to 231
 SPACE_GROUP_SYMBOL_TO_NUMBER = {
-    Spacegroup(no).symbol: no for no in range(1, MAX_SPACE_GROUP_NUMBER)
+    Spacegroup(no).symbol: no for no in range(1, MAX_SPACE_GROUP_NUMBER + 1)
 }  # Map of space group symbols to numbers
 
 m_package = Package()
@@ -187,7 +187,9 @@ class CrystalStructure(SampleProperty):
         description='The space group number (1-230)',
     )
     space_group = Quantity(
-        type=MEnum([Spacegroup(no).symbol for no in range(1, MAX_SPACE_GROUP_NUMBER)]),
+        type=MEnum(
+            [Spacegroup(no).symbol for no in range(1, MAX_SPACE_GROUP_NUMBER + 1)]
+        ),
         description='The space group symbol',
     )
     a = Quantity(
@@ -239,7 +241,7 @@ class CrystalStructure(SampleProperty):
         super().normalize(archive, logger)
 
         if self.space_group_nbr and not self.space_group:
-            if 1 <= self.space_group_nbr < MAX_SPACE_GROUP_NUMBER:
+            if 1 <= self.space_group_nbr <= MAX_SPACE_GROUP_NUMBER:
                 self.space_group = Spacegroup(self.space_group_nbr).symbol
             else:
                 logger.warning(


### PR DESCRIPTION
-simply added space group nbr as Quantity in DTUCombinatorialSample's CrystalStructure subsection, because it is less prone to formatting error than space group label (like space group 164 = P3m1,m it is easiest and less ambigeous to pass/write a integer, than a formated space group name)

-added a normalizer logic to write space group number from provded space group label, and vice versa, using ASE