### PR TITLE
Explicitly define unit instead of shorthand to avoid confusion in pint

### DIFF
--- a/src/nomad_dtu_nanolab_plugin/schema_packages/sputtering.py
+++ b/src/nomad_dtu_nanolab_plugin/schema_packages/sputtering.py
@@ -1119,10 +1119,10 @@ class SourceOverview(ArchiveSection):
         type=np.float64,
         a_eln={
             'component': 'NumberEditQuantity',
-            'defaultDisplayUnit': 'kW*h',
+            'defaultDisplayUnit': 'kilowatt*hour',
             'label': 'Accumulated power (Energy)',
         },
-        unit='kW*h',
+        unit='kilowatt*hour',
         description=(
             'The accumulated power the target has been exposed to at the end of '
             'the deposition'


### PR DESCRIPTION
In the current definition of the unit `kW*h`, `h` is read as Planck's constant instead of hour. The GUI fails where this property is loaded (Sputtering app or when initializing `data.deposition_parameters.magkeeper3` subsection in DTUSputtering entry), running into the error: `SyntaxError: Unit "planck_constant" not found.`  