### PR TITLE
Fix Overview plot in DTUSputtering

### DIFF
--- a/src/nomad_dtu_nanolab_plugin/sputter_log_reader.py
+++ b/src/nomad_dtu_nanolab_plugin/sputter_log_reader.py
@@ -4334,7 +4334,10 @@ def quick_plot(df, Y, **kwargs):
     fig.update_layout(
         legend=dict(
             bgcolor='rgba(0,0,0,0)',  # Transparent legend background
-        )
+        ),
+        xaxis=dict(fixedrange=False),
+        yaxis=dict(fixedrange=False),
+        dragmode='zoom',
     )
 
     # Add vertical lines to separate the plots


### PR DESCRIPTION
The x-axis in the overview plot of DTUSputtering by default goes to a fixed old time range. This renders the plot to have no data. Only when the plot is reset, triggering autoscaling, can the data be seen.

This PR adds autoscaling as a layout setting in overview plots. Additionally, it adds selection zoom for the `quick_plot` function, allowing a selection box to zoom into the data.