### PR TITLE
Use list of entry types for substrate lookup

### DIFF
--- a/src/nomad_dtu_nanolab_plugin/schema_packages/sputtering.py
+++ b/src/nomad_dtu_nanolab_plugin/schema_packages/sputtering.py
@@ -222,7 +222,7 @@ class DtuSubstrateMounting(ArchiveSection):
         if self.substrate is None and isinstance(
             self.substrate_batch, DTUSubstrateBatch
         ):
-            substrate = self.substrate_batch.next_not_used_in(DTUSputtering)
+            substrate = self.substrate_batch.next_not_used_in([DTUSputtering])
             self.substrate = substrate
         if self.position_x is None or self.position_y is None or self.rotation is None:
             positions = {

--- a/src/nomad_dtu_nanolab_plugin/schema_packages/substrate.py
+++ b/src/nomad_dtu_nanolab_plugin/schema_packages/substrate.py
@@ -179,6 +179,7 @@ class DTUSubstrateBatch(Collection, Schema):
         section_def=ReadableIdentifiers,
     )
 
+    # new methods for searching substrates in use
     def next_used_in(
         self, entry_types: list[type[Schema]], negate: bool = False
     ) -> DTUSubstrate:

--- a/src/nomad_dtu_nanolab_plugin/schema_packages/substrate.py
+++ b/src/nomad_dtu_nanolab_plugin/schema_packages/substrate.py
@@ -180,8 +180,9 @@ class DTUSubstrateBatch(Collection, Schema):
     )
 
     def next_used_in(
-        self, entry_type: type[Schema], negate: bool = False
+        self, entry_types: list[type[Schema]], negate: bool = False
     ) -> DTUSubstrate:
+        """ """
         from nomad.search import MetadataPagination, search
 
         ref: DTUSubstrateReference
@@ -193,10 +194,10 @@ class DTUSubstrateBatch(Collection, Schema):
             substrate = ref.reference
             query = {
                 'section_defs.definition_qualified_name:all': [
-                    entry_type.m_def.qualified_name()
+                    entry_type.m_def.qualified_name() for entry_type in entry_types
                 ],
-                'entry_references.target_entry_id:all': [substrate.m_parent.entry_id],
             }
+            query['entry_references.target_entry_id:all'] = substrate.m_parent.entry_id
             search_result = search(
                 owner='all',
                 query=query,
@@ -209,8 +210,8 @@ class DTUSubstrateBatch(Collection, Schema):
                 return substrate
         return None
 
-    def next_not_used_in(self, entry_type: type[Schema]) -> DTUSubstrate:
-        return self.next_used_in(entry_type, negate=True)
+    def next_not_used_in(self, entry_types: list[type[Schema]]) -> DTUSubstrate:
+        return self.next_used_in(entry_types, negate=True)
 
     def generate_geometry(self) -> Geometry:
         """

--- a/src/nomad_dtu_nanolab_plugin/schema_packages/thermal.py
+++ b/src/nomad_dtu_nanolab_plugin/schema_packages/thermal.py
@@ -8,7 +8,6 @@ from nomad.datamodel.metainfo.annotations import (
     ELNComponentEnum,
     SectionProperties,
 )
-
 from nomad.metainfo.metainfo import MProxy, Package, Quantity, Section, SubSection
 from nomad_material_processing.vapor_deposition.pvd.thermal import ThermalEvaporation
 


### PR DESCRIPTION
Extends the `next_used_in` and `next_not_used_in` methods of SubstrateBatch to allow for multiple entry types. Currently, they accept one entry type (for example, DTUSputtering) based on which fresh substrates are generated. This PR allows using a list of entry types (for example, DTUSputtering, Evaporation, etc.) to find fresh substrates after tracking entries of different process types. 