### PR TITLE
Modify order of extensions declaration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,17 +68,17 @@ markdown_extensions:
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences:
-      custom_fences:
-        - name: mermaid
-          class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
   - toc:
       permalink: True
   - pymdownx.arithmatex:
       generic: true
   - mkdocs-click
   - pymdownx.extra
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 extra:
   generator: false
   homepage: https://nomad-lab.eu


### PR DESCRIPTION
`pymdown.extra` needs to be declared before superfences. This fixes the mermaid graphs not being rendered issue.