### PR TITLE
Add missing dep: scikit-learn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "nomad-analysis>=0.0.7",
     "openpyxl>3",
     "renishawwire @ git+https://github.com/alchem0x2A/py-wdf-reader.git",
-
+    "scikit-learn",
 ]
 
 [project.urls]


### PR DESCRIPTION
`sklearn` used in ` nomad_dtu_nanolab_plugin.schema_packages.rt` module but not declared in the pyproject.

Fixes the CI where NOMAD fails to load the  `nomad_dtu_nanolab_plugin.schema_packages.rt.DtuAutosamplerMeasurement` due to:
```sh
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/sarthak-kapoor/repositories/dtu/nomad-dtu-nanolab-plugin/src/nomad_dtu_nanolab_plugin/schema_packages/rt.py", line 25, in <module>
    from nomad_dtu_nanolab_plugin import autosampler_reader
  File "/home/sarthak-kapoor/repositories/dtu/nomad-dtu-nanolab-plugin/src/nomad_dtu_nanolab_plugin/autosampler_reader.py", line 9, in <module>
    from sklearn.linear_model import LinearRegression
ModuleNotFoundError: No module named 'sklearn'
```
This error is probably being handled by some try-block when nomad tries to load the schema, and the traceback is not available in the CI pytest logs.